### PR TITLE
KDE constructor from distribution input

### DIFF
--- a/kalepy/kde.py
+++ b/kalepy/kde.py
@@ -433,22 +433,22 @@ class KDE(object):
         """
 
         # For one dimension
-        if utils.really1d( bins ):
+        if utils.really1d(bins):
 
             # Convert bins into points
             dx = bins[2] - bins[1]
             points = bins[:-1] + 0.5 * dx
 
             # Normalize into a pdf
-            hist /= hist.sum() * dx
+            hist = hist / (hist.sum() * dx)
 
             if bandwidth == 'bin width':
                 bandwidth = dx
             
             return KDE(
-                dataset = points,
-                weights = hist,
-                bandwidth = bandwidth,
+                dataset=points,
+                weights=hist,
+                bandwidth=bandwidth,
                 *args,
                 **kwargs
             )
@@ -460,30 +460,30 @@ class KDE(object):
             centers = []
             dx_mult = 1.
             dxs = []
+            
             for bins_i in bins:
-
                 # Convert bins into points
                 dx = bins_i[2] - bins_i[1]
                 centers_i = bins_i[:-1] + 0.5 * dx
-                centers.append( centers_i )
+                centers.append(centers_i)
 
                 dx_mult *= dx
-                dxs.append( dx )
+                dxs.append(dx)
 
             # Normalize into a pdf
-            hist /= hist.sum() * dx_mult
+            hist = hist / (hist.sum() * dx_mult)
 
             # Transform into points
-            points = np.meshgrid( *centers, indexing='ij' )
-            points = [ _.flatten() for _ in points ]
+            points = np.meshgrid(*centers, indexing='ij')
+            points = [_.flatten() for _ in points]
 
             if bandwidth == 'bin width':
                 bandwidth = dxs
 
             return KDE(
-                dataset = points,
-                weights = hist.flatten(),
-                bandwidth = bandwidth,
+                dataset=points,
+                weights=hist.flatten(),
+                bandwidth=bandwidth,
                 *args,
                 **kwargs
             )

--- a/kalepy/kde.py
+++ b/kalepy/kde.py
@@ -403,6 +403,21 @@ class KDE(object):
 
         return points, values
 
+    @classmethod
+    def from_hist(cls, bins, hist, *args, **kwargs):
+        """Alternative constructor using a histogram as input instead of
+        individual data points.
+        """
+
+        # Convert bins into points
+        dx = bins[2] - bins[1]
+        points = bins[:-1] + 0.5 * dx
+
+        # Normalize into a pdf
+        hist /= hist.sum() * dx
+        
+        return KDE(dataset=points, weights=hist, *args, **kwargs)
+
     def pdf(self, *args, **kwargs):
         kwargs['probability'] = True
         return self.density(*args, **kwargs)

--- a/kalepy/kde.py
+++ b/kalepy/kde.py
@@ -474,7 +474,7 @@ class KDE(object):
             hist /= hist.sum() * dx_mult
 
             # Transform into points
-            points = np.meshgrid( *centers )
+            points = np.meshgrid( *centers, indexing='ij' )
             points = [ _.flatten() for _ in points ]
 
             if bandwidth == 'bin width':

--- a/kalepy/kde.py
+++ b/kalepy/kde.py
@@ -404,19 +404,89 @@ class KDE(object):
         return points, values
 
     @classmethod
-    def from_hist(cls, bins, hist, *args, **kwargs):
+    def from_hist(cls, bins, hist, bandwidth='bin width', *args, **kwargs):
         """Alternative constructor using a histogram as input instead of
         individual data points.
+
+        Arguments
+        ---------
+        bins : ([D,]N,) array_like of scalar
+            Histogram bins. If using multiple dimensions N can be different
+            for different dimensions.
+
+        hist : (N,[N,...]) array_like of scalar
+            Histogram to construct KDE from. If in multiple dimensions
+            dimensions can have different N.
+
+        bandwidth : str or float
+            Bandwidth. Defaults to width of bin in each dimension. Accepts
+            all arguments passed to bandwidth when constructed using __init__.
+
+        *args, **kwargs : tuple, dict
+            Arguments passed to __init__ constructor.
+
+        Returns
+        -------
+        kde : instance of KDE
+            Initialized KDE instance.
+
         """
 
-        # Convert bins into points
-        dx = bins[2] - bins[1]
-        points = bins[:-1] + 0.5 * dx
+        # For one dimension
+        if len( bins.shape ) == 1:
 
-        # Normalize into a pdf
-        hist /= hist.sum() * dx
-        
-        return KDE(dataset=points, weights=hist, *args, **kwargs)
+            # Convert bins into points
+            dx = bins[2] - bins[1]
+            points = bins[:-1] + 0.5 * dx
+
+            # Normalize into a pdf
+            hist /= hist.sum() * dx
+
+            if bandwidth == 'bin width':
+                bandwidth = dx
+            
+            return KDE(
+                dataset = points,
+                weights = hist,
+                bandwidth = bandwidth,
+                *args,
+                **kwargs
+            )
+
+        # For multiple dimensions
+        else:
+
+            # Convert bins into points
+            centers = []
+            dx_mult = 1.
+            dxs = []
+            for bins_i in bins:
+
+                # Convert bins into points
+                dx = bins_i[2] - bins_i[1]
+                centers_i = bins_i[:-1] + 0.5 * dx
+                centers.append( centers_i )
+
+                dx_mult *= dx
+                dxs.append( dx )
+
+            # Normalize into a pdf
+            hist /= hist.sum() * dx_mult
+
+            # Transform into points
+            points = np.meshgrid( *centers )
+            points = [ _.flatten() for _ in points ]
+
+            if bandwidth == 'bin width':
+                bandwidth = dxs
+
+            return KDE(
+                dataset = points,
+                weights = hist.flatten(),
+                bandwidth = bandwidth,
+                *args,
+                **kwargs
+            )
 
     def pdf(self, *args, **kwargs):
         kwargs['probability'] = True

--- a/kalepy/kde.py
+++ b/kalepy/kde.py
@@ -433,7 +433,7 @@ class KDE(object):
         """
 
         # For one dimension
-        if len( bins.shape ) == 1:
+        if utils.really1d( bins ):
 
             # Convert bins into points
             dx = bins[2] - bins[1]

--- a/kalepy/tests/test_kde.py
+++ b/kalepy/tests/test_kde.py
@@ -557,10 +557,8 @@ class Test_KDE_Construct_From_Hist(object):
     def test_compare_1d(self):
         print("\n|Test_KDE_Construct_From_Hist:test_compare_1d()|")
 
-        # data = np.random.normal(0.0, 1.0, 1000)
-
         # Create a pdf and histogram
-        xx = np.linspace(-5, 5, 10000)
+        xx = np.linspace(-5, 5, 10001)
         pdf = np.exp(-xx*xx/2) / np.sqrt(2*np.pi)
         bins = np.zeros(xx.size + 1)
         dx = xx[1] - xx[0]
@@ -572,7 +570,31 @@ class Test_KDE_Construct_From_Hist(object):
 
         # Check that the KDE pdf matches the true pdf
         xx, pdf_kde = kde.density(xx, probability=True)
-        np.testing.assert_allclose( pdf, pdf_kde, atol=0.01 )
+        np.testing.assert_allclose( pdf, pdf_kde, atol=1e-5 )
+
+    def test_compare_2d(self):
+        print("\n|Test_KDE_Construct_From_Hist:test_compare_2d()|")
+
+        # Create a pdf and histogram
+        xx = np.linspace(-5, 5, 101)
+        yy = np.linspace(-5, 5, 101)
+        xx_grid, yy_grid = np.meshgrid( xx, yy )
+        hist = np.exp(-xx_grid*xx_grid/2 - yy_grid*yy_grid/2 - xx_grid*yy_grid/2)
+        bins = np.zeros(xx.size + 1)
+        dx = xx[1] - xx[0]
+        bins[:-1] = xx - 0.5 * dx
+        bins[-1] = xx[-1] + 0.5 * dx
+        bins = np.array([ bins, ]*2)
+                
+        # Construct a KDE from the histogram
+        kde = kale.KDE.from_hist(bins, hist)
+
+        # Check that the KDE pdf matches the true pdf
+        points = [ xx_grid.flatten(), yy_grid.flatten() ]
+        points, pdf_kde = kde.density( points, probability=True)
+        pdf = hist / ( hist.sum() * dx * dx )
+        np.testing.assert_allclose( pdf.flatten(), pdf_kde, atol=0.01 )
+
 
 # Run all methods as if with `nosetests ...`
 if __name__ == "__main__":

--- a/kalepy/tests/test_kde.py
+++ b/kalepy/tests/test_kde.py
@@ -548,6 +548,32 @@ class Test_KDE_Resample(object):
         return
 
 
+class Test_KDE_Construct_From_Hist(object):
+
+    @classmethod
+    def setup_class(cls):
+        np.random.seed(9865)
+
+    def test_compare_1d(self):
+        print("\n|Test_KDE_Construct_From_Hist:test_compare_1d()|")
+
+        # data = np.random.normal(0.0, 1.0, 1000)
+
+        # Create a pdf and histogram
+        xx = np.linspace(-5, 5, 10000)
+        pdf = np.exp(-xx*xx/2) / np.sqrt(2*np.pi)
+        bins = np.zeros(xx.size + 1)
+        dx = xx[1] - xx[0]
+        bins[:-1] = xx - 0.5 * dx
+        bins[-1] = xx[-1] + 0.5 * dx
+        
+        # Construct a KDE from the histogram
+        kde = kale.KDE.from_hist(bins, pdf)
+
+        # Check that the KDE pdf matches the true pdf
+        xx, pdf_kde = kde.density(xx, probability=True)
+        np.testing.assert_allclose( pdf, pdf_kde, atol=0.01 )
+
 # Run all methods as if with `nosetests ...`
 if __name__ == "__main__":
     run_module_suite()

--- a/notebooks/kde.ipynb
+++ b/notebooks/kde.ipynb
@@ -740,6 +740,155 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Alternative Constructor\n",
+    "\n",
+    "Construct a KDE from a histogram instead."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 1D"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create input histograms and output kdes\n",
+    "ns = 10**np.arange( 2, 5 )\n",
+    "xx_all = np.linspace(-5, 5, ns.max() + 1)\n",
+    "\n",
+    "xxs = []\n",
+    "pdf_kdes = []\n",
+    "for n in ns:\n",
+    "    print( n )\n",
+    "    xx = np.linspace(-5, 5, n + 1)                                            \n",
+    "    pdf = np.exp(-xx*xx/2) / np.sqrt(2*np.pi)\n",
+    "    dx = xx[1] - xx[0]                                                      \n",
+    "    bins = np.zeros(xx.size + 1)                                            \n",
+    "    bins[:-1] = xx - 0.5 * dx                                               \n",
+    "    bins[-1] = xx[-1] + 0.5 * dx  \n",
+    "    \n",
+    "    # Construct a KDE from the histogram                                    \n",
+    "    kde = kale.KDE.from_hist(bins, pdf) \n",
+    "    \n",
+    "    # Check that the KDE pdf matches the true pdf                           \n",
+    "    xx_all, pdf_kde = kde.density(xx_all, probability=True)  \n",
+    "    \n",
+    "    xxs.append( xx )\n",
+    "    pdf_kdes.append( pdf_kde )"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure( figsize=(8,6), facecolor='w' )\n",
+    "ax = plt.gca()\n",
+    "\n",
+    "ax.plot(\n",
+    "    xx_all,\n",
+    "    pdf,\n",
+    "    color = 'k',\n",
+    "    linewidth = 15,\n",
+    "    zorder = -10,\n",
+    "    label = 'true',\n",
+    ")\n",
+    "\n",
+    "for i, pdf_kde in enumerate( pdf_kdes ):\n",
+    "    \n",
+    "    ax.plot(\n",
+    "        xx_all,\n",
+    "        pdf_kde,\n",
+    "        color = plt.get_cmap( 'viridis' )( np.log10( ns[i] ) / np.log10( ns.max() ) ),\n",
+    "        label = 'dx = {:.3g}'.format( xxs[i][2] - xxs[i][1] ),\n",
+    "        zorder = 10 - i,\n",
+    "        linewidth = 3 + i*2,\n",
+    "    )\n",
+    "    \n",
+    "ax.legend(\n",
+    "    prop = { 'size': 16, },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## 2D"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Create input histograms and output kdes\n",
+    "xx = np.linspace(-5, 5, 101)                                            \n",
+    "yy = np.linspace(-5, 5, 101)                                            \n",
+    "xx_grid, yy_grid = np.meshgrid( xx, yy )                                \n",
+    "hist = np.exp(-xx_grid*xx_grid/2 - yy_grid*yy_grid/2 - xx_grid*yy_grid/2) \n",
+    "pdf = hist / ( hist.sum() * dx * dx )\n",
+    "bins = np.zeros(xx.size + 1)                                            \n",
+    "dx = xx[1] - xx[0]                                                      \n",
+    "bins[:-1] = xx - 0.5 * dx                                               \n",
+    "bins[-1] = xx[-1] + 0.5 * dx                                            \n",
+    "bins = np.array([ bins, ]*2)                                            \n",
+    "\n",
+    "# Construct a KDE from the histogram                                    \n",
+    "kde = kale.KDE.from_hist(bins, hist)                                    \n",
+    "\n",
+    "# Check that the KDE pdf matches the true pdf                           \n",
+    "points = [ xx_grid.flatten(), yy_grid.flatten() ]                       \n",
+    "points, pdf_kde = kde.density( points, probability=True) "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "fig = plt.figure( figsize=(8,8), facecolor='w' )\n",
+    "ax = plt.gca()\n",
+    "\n",
+    "cs = ax.contour(\n",
+    "    xx_grid,\n",
+    "    yy_grid,\n",
+    "    pdf,\n",
+    "    colors = 'k',\n",
+    "    linewidths = 10,\n",
+    "    labels = 'true',\n",
+    ")\n",
+    "cs.collections[0].set_label( 'true' )\n",
+    "\n",
+    "cs_kde = ax.contour(\n",
+    "    xx_grid,\n",
+    "    yy_grid,\n",
+    "    pdf_kde.reshape( xx_grid.shape ),\n",
+    "    linewidths = 3,\n",
+    "    colors = 'r',\n",
+    ")\n",
+    "cs_kde.collections[0].set_label( 'KDE' )\n",
+    "\n",
+    "ax.set_aspect( 'equal' )\n",
+    "\n",
+    "ax.legend(\n",
+    "    prop = { 'size': 16, },\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Other Kernels"
    ]
   },
@@ -1346,7 +1495,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.8.5"
+   "version": "3.8.3"
   },
   "toc": {
    "base_numbering": 1,
@@ -1397,5 +1546,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 4
 }


### PR DESCRIPTION
This PR enables a KDE instance to be created using a known distribution as input. This is done by considering each histogram (distribution) bin as a separate point, and weighting each point by its value.

The PR includes:
* new KDE constructor in `kde.py`
* new tests in `test_kde.py`
* new example usage in `kde.ipynb`